### PR TITLE
chore(grunt): use load-grunt-tasks module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ var mountFolder = function (connect, dir) {
 
 module.exports = function (grunt) {
   // load all grunt tasks
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  require('load-grunt-tasks')(grunt);
 
   // configurable paths
   var yeomanConfig = {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "grunt-rev": "~0.1.0",
     "grunt-karma": "~0.3.0",
     "grunt-open": "~0.2.0",
-    "matchdep": "~0.1.1",
     "grunt-google-cdn": "~0.1.1",
     "grunt-ngmin": "~0.0.2",
     "grunt-angular-templates": "~0.3.8",
     "grunt-recess": "~0.4.0",
-    "grunt-concurrent": "~0.4.0"
+    "grunt-concurrent": "~0.4.0",
+    "load-grunt-tasks": "~0.2.0"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Makes it way more easier to maintain grunt plugin loading instead of matchdep.
