### PR TITLE
Fixing variables declaration to come before the use

### DIFF
--- a/app/styles/style.less
+++ b/app/styles/style.less
@@ -1,5 +1,5 @@
-@import "mixins.less";
 @import "variables.less";
+@import "mixins.less";
 
 [date-picker-wrapper]{
   position: relative !important;


### PR DESCRIPTION
It doesn't work on dotless if you use variables before they are declared
