### PR TITLE
Date range datepickers always set to show correct dates when opened

### DIFF
--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -39,6 +39,8 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
     },
     link: function (scope, element, attrs, ngModel) {
 
+      var arrowClick = false;
+
       scope.date = new Date(scope.model || new Date());
       scope.views = datePickerConfig.views.concat();
       scope.view = attrs.view || datePickerConfig.view;
@@ -107,7 +109,13 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
 
       function update() {
         var view = scope.view;
+
+        if (scope.model && !arrowClick) {
+          scope.date = new Date(scope.model);
+          arrowClick = false;
+        }
         var date = scope.date;
+
         switch (view) {
         case 'year':
           scope.years = datePickerUtils.getVisibleYears(date);
@@ -156,6 +164,7 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
           date.setHours(date.getHours() + delta);
           break;
         }
+        arrowClick = true;
         update();
       };
 


### PR DESCRIPTION
Example for this can be found here https://rawgit.com/g00fy-/angular-datepicker/master/app/index.html. When you select dates for date range, also pick start and pick end dates on a date range button change. But when you click on a date range button it's always current moth that is shown. This is a small fix for that.