### PR TITLE
Added support for Browserify and Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./dist/index.js');
+module.exports = 'datePicker';
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "angular-datepicker",
   "version": "1.0.5",
-  "dependencies": {},
+  "main": "dist/index.js",
+  "repository": {
+    "url": "https://github.com/g00fy-/angular-datepicker.git"
+  },
+  "dependencies": {},,
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "url": "https://github.com/g00fy-/angular-datepicker.git"
   },
-  "dependencies": {},,
+  "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.0",


### PR DESCRIPTION
Added 'datePicker' to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

angular.module('myApp', [require('angular-datepicker')]);

This is helpful for Browserify and Webpack.