### PR TITLE
Updated main in package.json to point to the new index.js for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-datepicker",
   "version": "1.0.5",
-  "main": "dist/index.js",
+  "main": "index.js",
   "repository": {
     "url": "https://github.com/g00fy-/angular-datepicker.git"
   },


### PR DESCRIPTION
My apology for the second commit, but in order for npm to make use of the new index.js with module.exports, etc. it needs to reference the exports file in main.