### PR TITLE
bower.json: fixed version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-datepicker",
   "license": "MIT",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": [
     "./dist/index.js",
     "./dist/index.css"


### PR DESCRIPTION
Prevents "mismatch Version declared in the json (1.0.5) is different than the resolved one (1.0.6)" warning from Bower.