### PR TITLE
Fixing Issue #113: navigating to next/previous month will skip a mont…

### DIFF
--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -188,7 +188,11 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
           date.setFullYear(date.getFullYear() + delta);
           break;
         case 'date':
+          var dt = new Date(date);
           date.setMonth(date.getMonth() + delta);
+          if (date.getDate() < dt.getDate()) {
+            date.setDate(0);
+          }
           break;
         case 'hours':
         /*falls through*/


### PR DESCRIPTION
…h if the original month has more days than the target month (see http://www.htmlgoodies.com/beyond/javascript/javascript-date-calculations-for-months.html - Adding Months Without Rolling Over)