### PR TITLE
Updates templates urls to hit the templateCache

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 var Module = angular.module('datePicker', []);
 
 Module.constant('datePickerConfig', {
-  template: 'templates/datepicker.html',
+  template: 'app/templates/datepicker.html',
   view: 'month',
   views: ['year', 'month', 'date', 'hours', 'minutes'],
   step: 5
@@ -413,7 +413,7 @@ var Module = angular.module('datePicker');
 
 Module.directive('dateRange', function () {
   return {
-    templateUrl: 'templates/daterange.html',
+    templateUrl: 'app/templates/daterange.html',
     scope: {
       start: '=',
       end: '='


### PR DESCRIPTION
Adding the plugin to an angular application without including the template files at the specified path will prevent the plugin from working at all. The templateCache has probably been put there so the users of the plugin don't necessarily have to include the template files at that exact path.

However, the requested path and the cached path differ, so AngularJS makes a request to the template path and fails. This change updates the request template path to match the cache.