### PR TITLE
Improvement: Added Invalid Date handling 

### DIFF
--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -161,24 +161,28 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
           scope.date = new Date(scope.model);
           arrowClick = false;
         }
-        var date = scope.date;
+        var refDate = scope.date;
+        // Default the picker menu to the current date when passed an invalid date (e.g. 'year' view of 2010-2020 is more user friendly than 1899-1899).
+        if ( !datePickerUtils.isValidDate(refDate)) {
+          refDate = new Date();
+        }
 
         switch (view) {
           case 'year':
-            scope.years = datePickerUtils.getVisibleYears(date);
+            scope.years = datePickerUtils.getVisibleYears(refDate);
             break;
           case 'month':
-            scope.months = datePickerUtils.getVisibleMonths(date);
+            scope.months = datePickerUtils.getVisibleMonths(refDate);
             break;
           case 'date':
             scope.weekdays = scope.weekdays || datePickerUtils.getDaysOfWeek();
-            scope.weeks = datePickerUtils.getVisibleWeeks(date);
+            scope.weeks = datePickerUtils.getVisibleWeeks(refDate);
             break;
           case 'hours':
-            scope.hours = datePickerUtils.getVisibleHours(date);
+            scope.hours = datePickerUtils.getVisibleHours(refDate);
             break;
           case 'minutes':
-            scope.minutes = datePickerUtils.getVisibleMinutes(date, step);
+            scope.minutes = datePickerUtils.getVisibleMinutes(refDate, step);
             break;
         }
       }


### PR DESCRIPTION
Improvement: Added Invalid Date handling for setting up the current view when calendar is toggled. The view is focused on the current date instead of some day in 1899.

My implementation has cases where "---" gets set on the model (multi-object editing related) which resulted in issues related to the datepicker starting at a date in the year 1899. The user would have to manually navigate back to more current years before they could narrow down the date they want to pick.

This fix shouldn't be affecting the model value at all.