### PR TITLE
date-change callback - distinguish explicit selection

### DIFF
--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -117,7 +117,7 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
 
         var nextView = scope.views[scope.views.indexOf(scope.view) + 1];
         if ((!nextView || partial) || scope.model) {
-          setDate(date);
+          setDate(date, true);
         }
 
         if (nextView) {
@@ -130,18 +130,18 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
         }
       };
 
-      setDate = function (date) {
+      setDate = function (date, explicit) {
         if (date) {
           scope.model = date;
           if (ngModel) {
             ngModel.$setViewValue(date);
           }
         }
-        scope.$emit('setDate', scope.model, scope.view);
+        scope.$emit('setDate', scope.model, scope.view, explicit);
 
         //This is duplicated in the new functionality.
         if (scope.callbackOnSetDate) {
-          scope.callbackOnSetDate(attrs.datePicker, scope.date);
+          scope.callbackOnSetDate(attrs.datePicker, scope.date, explicit);
         }
       };
 
@@ -265,7 +265,7 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
         date = clipDate(date);
         if (date) {
           scope.date = date;
-          setDate(date);
+          setDate(date, false);
           arrowClick = true;
           update();
         }

--- a/app/scripts/input.js
+++ b/app/scripts/input.js
@@ -200,10 +200,10 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
 
         //If the picker has already been shown before then we shouldn't be binding to events, as these events are already bound to in this scope.
         if (!shownOnce) {
-          scope.$on('setDate', function (event, date, view) {
+          scope.$on('setDate', function (event, date, view, explicit) {
             updateInput(event);
             if (dateChange) {
-              dateChange(attrs.ngModel, date);
+              dateChange(attrs.ngModel, date, explicit);
             }
             if (dismiss && views[views.length - 1] === view) {
               clear();


### PR DESCRIPTION
This change makes it possible for the date-change callback to distinguish between explicit and implicit date changes. An explicit date change happens when a user explicitly select an option (e.g. a given day in the date view). An implicit date change happens e.g. in next()/prev() navigation.

Before this change there is no way to distinguish what exactly the user is doing. This change is useful when an app needs to perform an action when a user selects an option (e.g. a day).