### PR TITLE
Fix input parsing from ng-model

### DIFF
--- a/app/scripts/input.js
+++ b/app/scripts/input.js
@@ -80,8 +80,9 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
       }
 
       function parser(viewValue) {
-        if (viewValue.length === format.length) {
-          return viewValue;
+        var parsed = moment(viewValue, format);
+        if (parsed.isValid()) {
+          return parsed;
         }
         return undefined;
       }


### PR DESCRIPTION
```
function parser(viewValue) {
  if (viewValue.length === format.length) {
    return viewValue;
  }
  return undefined;
}
```

The parser logic added to ng-model does not seem right. I am using `format="LL"` and no min/max date and what it means is that any string of length 2 is considered valid. I am adding moment's isValid() instead.