### PR TITLE
Make it possible to update timezone using events

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This fork of angular-datepicker contains several features.
   * `format`: Format string used to display dates on the input field. Set to default value if this value is falsy. 
     * See: [format options](http://momentjs.com/docs/#/displaying/format/)
 	* This option cannot be used on the `date-picker` directive directly, it must be used on a `date-time` input field.
+  * `timezone`: Time zone to use
 * The possible for the `view`, `minView` and `maxView` fields are:
   * `year`, `month`, `date`, `hours`, `minutes`.
 * The event is targeted at specific pickers using their `ID` attributes.

--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -344,6 +344,10 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
               attrs.maxView = data.maxView;
               updateViews = true;
             }
+            if (angular.isDefined(data.timezone)) {
+              tz = scope.tz = data.timezone;
+              updateViewData = true;
+            }
             attrs.view = data.view || attrs.view;
 
             if (updateViews) {

--- a/app/scripts/input.js
+++ b/app/scripts/input.js
@@ -176,6 +176,10 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
               if (angular.isDefined(data.maxView)) {
                 attrs.maxView = data.maxView;
               }
+              if (angular.isDefined(data.timezone)) {
+                timezone = attrs.timezone = data.timezone;
+                validateRequired = true;
+              }
               attrs.view = data.view || attrs.view;
 
               if (validateRequired) {


### PR DESCRIPTION
Currently, one can only set the timezone statically using an attribute. That is useless when user's timezone preference is fetched asynchronously using Ajax.

With this change, a rendered date-picker can be update once user's timezone preference is obtained.