### PR TITLE
Interpolate pickerId

### DIFF
--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -31,7 +31,7 @@ Module.filter('mFormat', function () {
   };
 });
 
-Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function datePickerDirective(datePickerConfig, datePickerUtils) {
+Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', '$interpolate', function datePickerDirective(datePickerConfig, datePickerUtils, $interpolate) {
 
   //noinspection JSUnusedLocalSymbols
   return {
@@ -70,7 +70,7 @@ Module.directive('datePicker', ['datePickerConfig', 'datePickerUtils', function 
         partial = !!attrs.partial,
         minDate = getDate('minDate'),
         maxDate = getDate('maxDate'),
-        pickerID = element[0].id,
+        pickerID = $interpolate(element[0].id)(scope),
         now = scope.now = createMoment(),
         selected = scope.date = createMoment(scope.model || now),
         autoclose = attrs.autoClose === 'true',

--- a/app/scripts/input.js
+++ b/app/scripts/input.js
@@ -41,7 +41,7 @@ Module.directive('dateTimeAppend', function () {
   };
 });
 
-Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfig', '$parse', 'datePickerUtils', function ($compile, $document, $filter, dateTimeConfig, $parse, datePickerUtils) {
+Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfig', '$parse', 'datePickerUtils', '$interpolate', function ($compile, $document, $filter, dateTimeConfig, $parse, datePickerUtils, $interpolate) {
   var body = $document.find('body');
   var dateFilter = $filter('mFormat');
 
@@ -56,7 +56,7 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         index = views.indexOf(view),
         dismiss = attrs.autoClose ? $parse(attrs.autoClose)(scope) : dateTimeConfig.autoClose,
         picker = null,
-        pickerID = element[0].id,
+        pickerID = $interpolate(element[0].id)(scope),
         position = attrs.position || dateTimeConfig.position,
         container = null,
         minDate = null,


### PR DESCRIPTION
Useful when date-picker is used under ng-repeat. The change allows you to use:
`input(type='text', name='date', id="editDate-{{item.id}}")`

As a result the ids remain unique and you can target them individually with an event if needed.