### PR TITLE
Min/Max validation on not required dates

### DIFF
--- a/app/scripts/input.js
+++ b/app/scripts/input.js
@@ -103,6 +103,12 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         maxValid = moment.isMoment(date);
       }
 
+      function isNotRequired(value) {
+        var required = $parse(attrs.ngRequired)(scope) || false;
+        //if a value is not required, and no value is specified pass the min check.
+        return (!required && !value);
+      }
+      
       ngModel.$formatters.push(formatter);
       ngModel.$parsers.unshift(parser);
 
@@ -110,6 +116,9 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         setMin(datePickerUtils.findParam(scope, attrs.minDate));
 
         ngModel.$validators.min = function (value) {
+          if (isNotRequired(value)) {
+            return true;
+          }
           //If we don't have a min / max value, then any value is valid.
           return minValid ? moment.isMoment(value) && (minDate.isSame(value) || minDate.isBefore(value)) : true;
         };
@@ -119,6 +128,9 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         setMax(datePickerUtils.findParam(scope, attrs.maxDate));
 
         ngModel.$validators.max = function (value) {
+          if (isNotRequired(value)) {
+            return true;
+          }
           return maxValid ? moment.isMoment(value) && (maxDate.isSame(value) || maxDate.isAfter(value)) : true;
         };
       }


### PR DESCRIPTION
This allows for support of specifying a min/max date range, but not requiring the field to be populated.

Standard min-date, and max-date attributes are still used.  This just takes into account the ng-required logic.  default is not required if there is no ng-required attribute.
