### PR TITLE
Min/Max validation on not required dates

### DIFF
--- a/app/scripts/input.js
+++ b/app/scripts/input.js
@@ -103,6 +103,12 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         maxValid = moment.isMoment(date);
       }
 
+      function isNotRequired(value) {
+        var required = $parse(attrs.ngRequired)(scope) || false;
+        //if a value is not required, and no value is specified pass the min check.
+        return (!required && !value);
+      }
+                
       ngModel.$formatters.push(formatter);
       ngModel.$parsers.unshift(parser);
 
@@ -110,6 +116,9 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         setMin(datePickerUtils.findParam(scope, attrs.minDate));
 
         ngModel.$validators.min = function (value) {
+          if (isNotRequired(value)) {
+            return true;
+          } 
           //If we don't have a min / max value, then any value is valid.
           return minValid ? moment.isMoment(value) && (minDate.isSame(value) || minDate.isBefore(value)) : true;
         };
@@ -119,6 +128,9 @@ Module.directive('dateTime', ['$compile', '$document', '$filter', 'dateTimeConfi
         setMax(datePickerUtils.findParam(scope, attrs.maxDate));
 
         ngModel.$validators.max = function (value) {
+          if (isNotRequired(value)) {
+            return true;
+          } 
           return maxValid ? moment.isMoment(value) && (maxDate.isSame(value) || maxDate.isAfter(value)) : true;
         };
       }


### PR DESCRIPTION
Updates to support allowing a min/max date, but not having the field be required.

Based on ngRequired logic.  If no ngRequired is specified defaults to false.
