### PR TITLE
Added support for empty date values

### DIFF
--- a/dist/angular-datepicker.js
+++ b/dist/angular-datepicker.js
@@ -31,6 +31,9 @@ var Module = angular.module('datePicker', []);
 //Moment format filter.
   Module.filter('mFormat', function () {
     return function (m, format, tz) {
+      if (m == null){
+        return ''
+      }
       if (!(moment.isMoment(m))) {
         return (m) ? moment(m).format(format) : '';
       }


### PR DESCRIPTION
Fixed error "Invalid date" #183. 
For example, django rest framework return null if value is empty. Without this fix, I always get error "Invalid date"
