### PR TITLE
fixes format filter when invalid date.

### DIFF
--- a/app/scripts/datePicker.js
+++ b/app/scripts/datePicker.js
@@ -25,7 +25,8 @@ Module.constant('datePickerConfig', {
 Module.filter('mFormat', function () {
   return function (m, format, tz) {
     if (!(moment.isMoment(m))) {
-      return moment(m).format(format);
+      var value = moment(m);
+      return value.isValid() ? value.format(format) : null;
     }
     return tz ? moment.tz(m, tz).format(format) : m.format(format);
   };

--- a/dist/angular-datepicker.js
+++ b/dist/angular-datepicker.js
@@ -32,7 +32,8 @@ var Module = angular.module('datePicker', []);
   Module.filter('mFormat', function () {
     return function (m, format, tz) {
       if (!(moment.isMoment(m))) {
-        return (m) ? moment(m).format(format) : '';
+        var value = moment(m);
+        return value.isValid() ? value.format(format) : null;
       }
       return tz ? moment.tz(m, tz).format(format) : m.format(format);
     };

--- a/test/spec/datePickerTest.js
+++ b/test/spec/datePickerTest.js
@@ -27,6 +27,20 @@ describe('Test date Picker Filter', function(){
 
     expect(formattedDate).toBe('2015_01_02');
   });
+
+  it('returns null when receiving an invalid date', function() {
+    var date = 'an invalid date';
+    var formattedDate = mFormatFilter(date, 'YYYY_MM_DD');
+
+    expect(formattedDate).toBe(null);
+  });
+
+  it('returns null when receiving null', function() {
+    var date = null;
+    var formattedDate = mFormatFilter(date, 'YYYY_MM_DD');
+
+    expect(formattedDate).toBe(null);
+  });
 });
 
 describe('Test date Picker Directive', function(){


### PR DESCRIPTION
There's an issue when the filter `mFormat` receives null or an invalid date (being date a date, moment or string object).

This PR checks for valid format. If not, it must return null.
